### PR TITLE
casting to object to fix inconsistent API response

### DIFF
--- a/src/Dukt/Vimeo.php
+++ b/src/Dukt/Vimeo.php
@@ -481,6 +481,7 @@ class Vimeo
 
         // Make sure our file sizes match up
         foreach ($verify->ticket->chunks as $chunk_check) {
+            $chunk_check = (object) $chunk_check;
             $chunk = $chunks[$chunk_check->id];
 
             if ($chunk['size'] != $chunk_check->size) {


### PR DESCRIPTION
sometimes (in my case - Dropr.com), response from API 

`$verify->ticket->chunks` is array of arrays, not objects.
