### PR TITLE
Wrong version number in README composer.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "dukt/vimeo": "0.1.*"
+        "dukt/vimeo": "1.0.*"
     }
 }
 ```


### PR DESCRIPTION
When using that composer.json you get this message:

Your requirements could not be resolved to an installable set of packages.
  Problem 1
- composer.json
  - The requested package dukt/vimeo 0.1.\* could not be found.
