### PR TITLE
Fix chunk size verification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dukt/vimeo",
+    "name": "jverb/vimeo",
     "type": "library",
     "description": "Composer wrapper for Vimeo PHP library",
     "keywords": ["youtube", "vimeo", "video", "videos"],

--- a/src/Dukt/Vimeo.php
+++ b/src/Dukt/Vimeo.php
@@ -481,9 +481,9 @@ class Vimeo
 
         // Make sure our file sizes match up
         foreach ($verify->ticket->chunks as $chunk_check) {
-            $chunk = $chunks[$chunk_check->id];
+            $chunk = $chunks[intval($chunk_check['id'])];
 
-            if ($chunk['size'] != $chunk_check->size) {
+            if ($chunk['size'] != $chunk_check['size']) {
                 // size incorrect, uh oh
                 echo "Chunk {$chunk_check->id} is actually {$chunk['size']} but uploaded as {$chunk_check->size}<br>";
             }


### PR DESCRIPTION
Trying to access property of non-object, change to access property of array. Ensure chunk id is integer when retrieving from array.
