### PR TITLE
Added branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     "require-dev": {
         "phpunit/phpunit": "~3.7.16",
         "squizlabs/php_codesniffer": "~1.4.4"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Currently using "dukt/vimeo": "0.1.*" fails for me. I can't remember if this is the solution, but I think it is.
